### PR TITLE
Add personality management to web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ ta.save("test-2.wav", wav, model.sr)
 ```
 See `example_tts.py` and `example_vc.py` for more examples.
 
+## Story Voice Web App
+
+You can run a small FastAPI application that serves a web interface for reading
+your stories aloud. The interface mimics the look of **StoryBlocks** and lets
+you save "personalities" (named voice samples) that can be reused for multiple
+stories. This is useful when testing in environments like GitHub Codespaces.
+
+```bash
+python webapp/app.py
+```
+
+Open the reported URL in your browser. Use the **Create Personality** form to
+upload a short `.wav` sample and give it a name. Then pick a personality from
+the dropdown or upload a temporary voice sample along with your story text or
+text file. The app will return synthesized audio with the selected voice.
+
 # Supported Lanugage
 Currenlty only English.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,10 @@ dependencies = [
     "diffusers==0.29.0",
     "resemble-perth==1.0.1",
     "conformer==0.3.2",
-    "safetensors==0.5.3"
+    "safetensors==0.5.3",
+    "fastapi>=0.110",
+    "uvicorn>=0.23",
+    "python-multipart>=0.0.7"
 ]
 
 [project.urls]

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,62 @@
+import os
+import tempfile
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+import torch
+from chatterbox.tts import ChatterboxTTS
+
+PERSONALITY_DIR = "webapp/personalities"
+
+app = FastAPI()
+app.mount("/static", StaticFiles(directory="webapp/static"), name="static")
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+model = None
+
+@app.on_event("startup")
+async def load_model():
+    global model
+    os.makedirs(PERSONALITY_DIR, exist_ok=True)
+    model = ChatterboxTTS.from_pretrained(DEVICE)
+
+@app.get("/")
+async def index():
+    with open("webapp/static/index.html", "r", encoding="utf8") as f:
+        return HTMLResponse(content=f.read())
+
+
+@app.get("/personalities")
+async def list_personalities():
+    names = [os.path.splitext(p)[0] for p in os.listdir(PERSONALITY_DIR) if p.endswith(".wav")]
+    return {"personalities": names}
+
+
+@app.post("/personalities")
+async def add_personality(name: str = Form(...), voice: UploadFile = File(...)):
+    path = os.path.join(PERSONALITY_DIR, f"{name}.wav")
+    with open(path, "wb") as f:
+        content = await voice.read()
+        f.write(content)
+    return JSONResponse({"status": "ok"})
+
+@app.post("/generate")
+async def generate(text: str = Form(...), personality: str = Form(None), voice: UploadFile = File(None)):
+    voice_path = None
+    if personality:
+        path = os.path.join(PERSONALITY_DIR, f"{personality}.wav")
+        if os.path.exists(path):
+            voice_path = path
+    if voice is not None:
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        content = await voice.read()
+        tmp.write(content)
+        tmp.flush()
+        voice_path = tmp.name
+    if not voice_path:
+        return JSONResponse({"error": "No voice sample provided"}, status_code=400)
+    wav = model.generate(text, audio_prompt_path=voice_path)
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as out:
+        import torchaudio as ta
+        ta.save(out.name, wav, model.sr)
+        return FileResponse(out.name, media_type="audio/wav", filename="output.wav")

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Story Voice</title>
+    <style>
+        body { background:#1e1e1e; color:#f0f0f0; font-family: Arial, sans-serif; margin:0; }
+        .wrapper { max-width:900px; margin:40px auto; padding:20px; background:#2b2b2b; border-radius:8px; }
+        h1 { text-align:center; margin-top:0; }
+        section { margin-top:30px; }
+        label { display:block; margin-top:10px; }
+        input, textarea, select { width:100%; padding:10px; margin-top:5px; background:#444; color:#fff; border:none; border-radius:4px; }
+        button { margin-top:15px; padding:10px 20px; background:#4e9a06; color:white; border:none; border-radius:4px; cursor:pointer; }
+        button:hover { background:#3c7a04; }
+        audio { display:block; margin-top:20px; width:100%; }
+    </style>
+</head>
+<body>
+<div class="wrapper">
+    <h1>Story Voice</h1>
+    <section id="create-personality">
+        <h2>Create Personality</h2>
+        <form id="personality-form">
+            <label for="pname">Name</label>
+            <input id="pname" required>
+            <label for="pvoice">Voice Sample (.wav)</label>
+            <input type="file" id="pvoice" accept=".wav" required>
+            <button type="submit">Save Personality</button>
+        </form>
+    </section>
+    <section id="story">
+        <h2>Generate Story</h2>
+        <form id="voice-form">
+            <label for="personality">Personality</label>
+            <select id="personality"></select>
+            <label for="text">Story Text</label>
+            <textarea id="text" placeholder="Paste your story"></textarea>
+            <label for="textFile">Or Upload Text File</label>
+            <input type="file" id="textFile" accept=".txt">
+            <label for="voiceFile">Temporary Voice Sample (.wav)</label>
+            <input type="file" id="voiceFile" accept=".wav">
+            <button type="submit">Generate</button>
+        </form>
+        <audio id="resultAudio" controls></audio>
+    </section>
+</div>
+<script>
+async function loadPersonalities(){
+    const res = await fetch('/personalities');
+    const data = await res.json();
+    const sel = document.getElementById('personality');
+    sel.innerHTML = '';
+    data.personalities.forEach(p=>{
+        const opt = document.createElement('option');
+        opt.value = p; opt.textContent = p; sel.appendChild(opt);
+    });
+}
+
+const pForm = document.getElementById('personality-form');
+pForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const fd = new FormData();
+    fd.append('name', document.getElementById('pname').value);
+    fd.append('voice', document.getElementById('pvoice').files[0]);
+    await fetch('/personalities', {method:'POST', body:fd});
+    document.getElementById('pname').value = '';
+    document.getElementById('pvoice').value = '';
+    await loadPersonalities();
+});
+
+const form = document.getElementById('voice-form');
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fd = new FormData();
+    const textFile = document.getElementById('textFile').files[0];
+    let text = document.getElementById('text').value;
+    if(textFile){
+        text = await textFile.text();
+    }
+    fd.append('text', text);
+    const personality = document.getElementById('personality').value;
+    if(personality){ fd.append('personality', personality); }
+    const voiceFile = document.getElementById('voiceFile').files[0];
+    if(voiceFile){ fd.append('voice', voiceFile); }
+    const res = await fetch('/generate', { method: 'POST', body: fd });
+    if(res.ok){
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        document.getElementById('resultAudio').src = url;
+    }else{
+        alert('Error generating audio');
+    }
+});
+
+loadPersonalities();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expand Story Voice web interface with style similar to StoryBlocks
- allow saving named voice samples as personalities
- update README with new workflow instructions

## Testing
- `pytest -q`
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_685822ef98248321a907ba2e9c43023e