### PR TITLE
Fix webapp startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pip install -e .
 ```
 
 ```bash
-python webapp/app.py
+uvicorn webapp.app:app --host 0.0.0.0 --port 8000
 ```
 
 Open the reported URL in your browser. Use the **Create Personality** form to

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -60,3 +60,8 @@ async def generate(text: str = Form(...), personality: str = Form(None), voice: 
         import torchaudio as ta
         ta.save(out.name, wav, model.sr)
         return FileResponse(out.name, media_type="audio/wav", filename="output.wav")
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("webapp.app:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- fix instructions on how to run the web app in README
- make `webapp/app.py` start a server when executed directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584e926ffc8321ae0f6bb2bb84666b